### PR TITLE
adds dialog component

### DIFF
--- a/src/components/Dialog.svelte
+++ b/src/components/Dialog.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { dialogText as dialogTextStore, dialogTheme as dialogThemeStore, closeDialog } from '../utils/dialog';
+    let dialogRef: HTMLDialogElement | undefined;
+    let dialogText = '';
+    dialogTextStore.subscribe((value) => {
+        dialogText = value;
+        if (dialogText) {
+            dialogRef?.showModal()
+        } else {
+            dialogRef?.close();
+        }
+    });
+    dialogThemeStore.subscribe((value) => {
+        if (!dialogRef) return;
+        if (value === 'error') {
+            dialogRef.style.background = 'red';
+        } else if (value === 'secondary') {
+            dialogRef.style.background = 'gray';
+        } else {
+            dialogRef.style.background = '#05EDFF';
+        }
+    });
+    onMount(() => {
+        // clean up dialogState when closed
+        dialogRef?.addEventListener('close', closeDialog);
+    })
+</script>
+
+<dialog bind:this={dialogRef}>
+    {dialogText}
+    <button on:click={closeDialog}>ok</button>
+</dialog>
+
+<style>
+     dialog[open] {
+        background: #05EDFF;
+        color: white;
+        border: none;
+        padding: 1rem 2rem;
+        border-radius: 7px;
+
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+    dialog button {
+        border: none;
+        background: white;
+        color: black;
+        cursor: pointer;
+        padding: 5px 15px;
+        border-radius: 6px;
+        width: fit-content;
+        margin-top: 10px;
+        outline: none;
+    }
+    dialog button:hover {
+        transform: scale(1.2);
+    }
+</style>

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,27 @@
+import { writable } from 'svelte/store';
+
+type DialogTheme = 'primary' | 'error' | 'secondary';
+
+interface OpenDialog {
+    dialogContent: string;
+    dialogTheme?: DialogTheme;
+    shouldCloseWithTimeout?: boolean;
+}
+
+export const dialogText = writable('');
+export const dialogTheme = writable<DialogTheme>('primary');
+
+export function openDialog(props: OpenDialog) {
+    dialogText.set(props.dialogContent);
+    dialogTheme.set(props.dialogTheme || 'primary')
+    if (props.shouldCloseWithTimeout) {
+        setTimeout(() => {
+            closeDialog();
+        }, 2000);
+    }
+}
+
+export function closeDialog() {
+    dialogText.set('');
+    dialogTheme.set('primary')
+}


### PR DESCRIPTION
adds a new dialog component.

```
interface OpenDialog {
    dialogContent: string;
    dialogTheme?: DialogTheme;
    shouldCloseWithTimeout?: boolean;
}
```

The dialog is displayed by calling the `openDialog` function with a prop that includes `dialogText` (such as "Success!" or "There was an error"). This is a minimal dialog component intended mainly just to provide success/failure messages when users add comments or moderates approve/delete comments.